### PR TITLE
Fix jitter causing panics on wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["log", "rand"]
+wasm-bindgen = ["rand/wasm-bindgen"]
+stdweb = ["rand/stdweb"]
 
 [dependencies]
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
`getrandom`, which `rand` depends on, needs to know how to interface with JS in order to work. Otherwise, it causes an "unreachable" error:

https://github.com/rust-random/getrandom/tree/0ad1c7721455b644a775bb4647806ab631250c14#features