### PR TITLE
Make `rand` and `log` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,12 @@ categories = [
 maintenance = { status = "actively-developed" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["log", "rand"]
 
 [dependencies]
-log = "0.4"
-rand = "0.7"
+log = { version = "0.4", optional = true }
+rand = { version = "0.7", optional = true }
 wasm-timer = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
It feels like these should be opt-out.

If a user doesn't need jitter or doesn't care about logging, they might want to cut down the binary size a little bit.