### PR TITLE
add ability to configure exponential backoff exponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* allow for exponential backoff exponent to be configured [#5](https://github.com/softprops/again/pull/5)
+
 # 0.1.2
 
 * add features for `wasm-bindgen` and `stdweb` which enable `rand`'s equivalent [features](https://github.com/rust-random/getrandom/tree/0ad1c7721455b644a775bb4647806ab631250c14#features) [#2](https://github.com/softprops/again/pull/2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = { version = "0.7", optional = true }
 wasm-timer = "0.2"
 
 [dev-dependencies]
+approx = "0.3"
 pretty_env_logger = "0.4"
 reqwest = "0.10"
 tokio = { version = "0.2", features = ["rt-threaded","macros"] }


### PR DESCRIPTION
In order to allow for this in a useful way, the internal current
backoff was also modified from being an integer to a floating point
value.  This changes the behavior related to overflow some.