### PR TITLE
Add collect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * allow for exponential backoff exponent to be configured [#5](https://github.com/softprops/again/pull/5)
+* add `collect` [#6](https://github.com/softprops/again/pull/6)
 
 # 0.1.2
 


### PR DESCRIPTION
When batch fetching items from DynamoDB, it can happen that not all items are delivered at once, but instead there are `unprocessed_keys`, which will need to be fetched again with exponential backoff. This is an attempt at making that happen easily. 

It's meant as a first step. Ideally I would like a function that allows me catching both errors and certain results. But I thought I'd try this first to see if it's at all in line with what this project wants to do.