### PR TITLE
Implement `Condition` for `FnMut` rather than `Fn`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,7 +534,7 @@ impl<E> Condition<E> for Always {
 
 impl<F, E> Condition<E> for F
 where
-    F: Fn(&E) -> bool,
+    F: FnMut(&E) -> bool,
 {
     fn is_retryable(
         &mut self,


### PR DESCRIPTION
Condition takes self by mutable reference, and can therefore be implemented by `FnMut` (which is more general: every `Fn` is also `FnMut` and `FnOnce`, but not the other way around).