### PR TITLE
Cloudflare worker fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,12 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["log", "rand"]
-wasm-bindgen = ["getrandom/wasm-bindgen"]
+wasm-bindgen = ["futures-timer/wasm-bindgen"]
 
 [dependencies]
 log = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
-getrandom = { version = "0.2", optional = true }
-wasm-timer = "0.2"
+futures-timer = { version = "3" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,10 @@
 //! [dependencies]
 //! again = { version = "xxx", features = ["wasm-bindgen"] }
 //! ```
+use futures_timer::Delay;
 #[cfg(feature = "rand")]
 use rand::{distributions::OpenClosed01, thread_rng, Rng};
 use std::{cmp::min, future::Future, time::Duration};
-use wasm_timer::Delay;
 
 /// Retries a fallible `Future` with a default `RetryPolicy`
 ///


### PR DESCRIPTION
On a cloudflare worker the first retry will cause a silent panic with `wasm_timer::Delay`.
Also the getrandom doesn't seems to be used.

Signed-off-by: Anthony Griffon <anthony@griffon.one>